### PR TITLE
Fix laps driven estimate calculation and a random case when grip rese…

### DIFF
--- a/LiveConditionsServerPlugin.cs
+++ b/LiveConditionsServerPlugin.cs
@@ -202,7 +202,7 @@ namespace AcTools.ServerPlugin.DynamicConditions {
 
                 if (PluginManager != null) {
                     foreach (var info in PluginManager.GetDriverInfos()) {
-                        if (info?.IsConnected == true) {
+                        if (info?.IsConnected == true && !float.IsNaN(info.CurrentSpeed) && info.CurrentSpeed > 0) {
                             var drivenDistanceKm = info.CurrentSpeed * UpdateRainPeriod.TotalHours;
                             _drivenLapsEstimate += drivenDistanceKm / _lapLengthKm;
                         }


### PR DESCRIPTION
…ts to 60%

In our servers we observed that in some cases info.CurrentSpeed comes as NaN - this corrupts whole grip calculation, and resets grip value to 0 (it is clamped to 60%).